### PR TITLE
Use HACS `plugin` type for Lovelace card and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A custom Home Assistant Lovelace card for HACS that renders a modern PV/energy o
 
 ## Installation (HACS)
 
-1. Add this repository as a **Custom repository** in HACS with type **Dashboard**.
+1. Add this repository as a **Custom repository** in HACS with type **Plugin** (this is the correct HACS type for Lovelace custom cards).
 2. Install **HA Solar Dashboard Card**.
 3. Restart Home Assistant (or reload resources).
 4. Add the card in Lovelace.
@@ -61,5 +61,5 @@ units:
 
 ## Troubleshooting HACS install
 
-If HACS shows an "Unknown error" while downloading, make sure you selected repository type **Dashboard** (frontend) and then clear the failed download from HACS before retrying.
+If HACS shows an "Unknown error" while downloading, make sure you selected repository type **Plugin**. If you previously added it as Dashboard, remove the failed entry in HACS and add it again as Plugin before retrying.
 This repository ships the card file directly at the repository root (`ha-solar-dashboard-card.js`), which is required by HACS frontend installs.

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "HA Solar Dashboard Card",
+  "type": "plugin",
   "content_in_root": true,
   "filename": "ha-solar-dashboard-card.js",
   "render_readme": true,


### PR DESCRIPTION
### Motivation
- Ensure the repository is registered in HACS with the correct type for Lovelace custom cards so installs do not fail due to using the wrong repository type.

### Description
- Update `README.md` to instruct adding the repository as a HACS `Plugin` instead of `Dashboard` and adjust the troubleshooting text accordingly, and add `"type": "plugin"` to `hacs.json`.

### Testing
- No automated tests were run for this documentation/metadata change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4893bfb808327818b54fd34aef143)