### PR TITLE
Enable HACS zip_release and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ units:
 
 If HACS shows an "Unknown error" while downloading, make sure you selected repository type **Dashboard**. If you previously added it as a different type, remove the failed entry in HACS and add it again as Dashboard before retrying.
 
-This repository ships the HACS entry file in `dist/ha-solar-dashboard.js` and declares `ha-solar-dashboard.js` in `hacs.json`. The filename must match the repository name (`ha-solar-dashboard`) so HACS can identify it as a valid Dashboard plugin. Tagged GitHub releases must include `ha-solar-dashboard.js` as a release asset; the release workflow publishes that asset automatically for new `v*` tags.
+This repository ships the HACS entry file in `dist/ha-solar-dashboard.js` and declares `ha-solar-dashboard.js` in `hacs.json`. The filename must match the repository name (`ha-solar-dashboard`) so HACS can identify it as a valid Dashboard plugin. HACS is configured with `zip_release: true`, so it installs from the GitHub release source archive and reads `ha-solar-dashboard.js` directly from the repository root. This avoids failures caused by missing or renamed release assets.

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,6 @@
   "name": "HA Solar Dashboard Card",
   "filename": "ha-solar-dashboard.js",
   "render_readme": true,
-  "homeassistant": ">=2023.8.0"
+  "homeassistant": ">=2023.8.0",
+  "zip_release": true
 }


### PR DESCRIPTION
### Motivation
- Prevent HACS "Unknown error" installs caused by missing or renamed release assets by configuring HACS to install from the GitHub release source archive.

### Description
- Add `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78c44dc748327aa2f3e88e32c015a)