### PR TITLE
Add localized READMEs for de, es, fr, pl, pt

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,25 @@
+# HA Solar Dashboard Card (Deutsch)
+
+Eine benutzerdefinierte Home-Assistant-Lovelace-Karte für HACS mit moderner PV-/Energieübersicht auf Basis eines Hausbildes.
+
+## Beispiel
+
+![HA Solar Dashboard Card example](images/home.png)
+
+## Funktionen
+
+- Hintergrundbild (Haus/PV-Design)
+- Automatischer Tag-/Nachtbildwechsel über `sun.sun` (`*_tag.png` bei Tag)
+- Overlay-Widgets auf frei positionierbaren Punkten
+- Wählbare Hauslayouts aus dem `images`-Ordner
+- Konfigurierbare Entitäten für PV, Batterie, Wechselrichter, Wallbox und Gesamtleistung
+- Einzelne Boxen können ausgeblendet werden
+
+## Installation (HACS)
+
+1. Repository in HACS als **Custom repository** mit Typ **Dashboard** hinzufügen.
+2. **HA Solar Dashboard Card** installieren.
+3. Home Assistant neu starten (oder Ressourcen neu laden).
+4. Karte in Lovelace hinzufügen.
+
+> Detaillierte Konfigurationsoptionen finden Sie in der englischen Standard-README: [README.md](README.md)

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,25 @@
+# HA Solar Dashboard Card (Español)
+
+Una tarjeta Lovelace personalizada para Home Assistant en HACS con una vista moderna de energía/PV basada en imagen.
+
+## Ejemplo
+
+![HA Solar Dashboard Card example](images/home.png)
+
+## Características
+
+- Imagen de fondo (casa/diseño PV)
+- Cambio automático día/noche mediante `sun.sun` (`*_tag.png` durante el día)
+- Widgets superpuestos con posicionamiento libre X/Y
+- Diseños de casa seleccionables desde la carpeta `images`
+- Entidades configurables (PV, batería, inversor, wallbox, potencia total)
+- Se pueden ocultar cajas individuales
+
+## Instalación (HACS)
+
+1. Añade este repositorio a HACS como **Custom repository** de tipo **Dashboard**.
+2. Instala **HA Solar Dashboard Card**.
+3. Reinicia Home Assistant (o recarga recursos).
+4. Añade la tarjeta en Lovelace.
+
+> Para todas las opciones de configuración detalladas, revisa la README estándar en inglés: [README.md](README.md)

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,25 @@
+# HA Solar Dashboard Card (Français)
+
+Une carte Lovelace Home Assistant personnalisée pour HACS, avec une vue moderne de l'énergie/PV basée sur une image.
+
+## Exemple
+
+![HA Solar Dashboard Card example](images/home.png)
+
+## Fonctionnalités
+
+- Image d'arrière-plan (maison/design PV)
+- Basculement automatique jour/nuit via `sun.sun` (`*_tag.png` en journée)
+- Widgets superposés avec positionnement X/Y libre
+- Modèles de maisons sélectionnables depuis `images`
+- Entités configurables (PV, batterie, onduleur, wallbox, puissance totale)
+- Masquage possible de boîtes individuelles
+
+## Installation (HACS)
+
+1. Ajoutez ce dépôt dans HACS comme **Custom repository** de type **Dashboard**.
+2. Installez **HA Solar Dashboard Card**.
+3. Redémarrez Home Assistant (ou rechargez les ressources).
+4. Ajoutez la carte dans Lovelace.
+
+> Pour toutes les options de configuration détaillées, consultez la README anglaise standard : [README.md](README.md)

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,0 +1,25 @@
+# HA Solar Dashboard Card (Polski)
+
+Niestandardowa karta Lovelace dla Home Assistant w HACS, pokazująca nowoczesny podgląd energii/PV oparty na obrazie.
+
+## Przykład
+
+![HA Solar Dashboard Card example](images/home.png)
+
+## Funkcje
+
+- Tło graficzne (dom/projekt PV)
+- Automatyczne przełączanie dzień/noc przez `sun.sun` (`*_tag.png` w dzień)
+- Nakładki z dowolnym pozycjonowaniem X/Y
+- Wybieralne układy domów z folderu `images`
+- Konfigurowalne encje (PV, bateria, falownik, wallbox, moc całkowita)
+- Możliwość ukrywania pojedynczych pól
+
+## Instalacja (HACS)
+
+1. Dodaj to repozytorium do HACS jako **Custom repository** typu **Dashboard**.
+2. Zainstaluj **HA Solar Dashboard Card**.
+3. Uruchom ponownie Home Assistant (lub przeładuj zasoby).
+4. Dodaj kartę w Lovelace.
+
+> Pełne opcje konfiguracji znajdziesz w standardowej angielskiej README: [README.md](README.md)

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,0 +1,25 @@
+# HA Solar Dashboard Card (Português)
+
+Um cartão Lovelace personalizado para Home Assistant no HACS com visão moderna de energia/PV baseada em imagem.
+
+## Exemplo
+
+![HA Solar Dashboard Card example](images/home.png)
+
+## Funcionalidades
+
+- Imagem de fundo (casa/design PV)
+- Troca automática dia/noite via `sun.sun` (`*_tag.png` durante o dia)
+- Widgets sobrepostos com posicionamento livre em X/Y
+- Layouts de casa selecionáveis da pasta `images`
+- Entidades configuráveis (PV, bateria, inversor, wallbox, potência total)
+- Caixas individuais podem ser ocultadas
+
+## Instalação (HACS)
+
+1. Adicione este repositório ao HACS como **Custom repository** do tipo **Dashboard**.
+2. Instale **HA Solar Dashboard Card**.
+3. Reinicie o Home Assistant (ou recarregue os recursos).
+4. Adicione o cartão no Lovelace.
+
+> Para opções completas de configuração, consulte a README padrão em inglês: [README.md](README.md)


### PR DESCRIPTION
### Motivation

- Provide localized documentation to make the HA Solar Dashboard Card easier to discover and install for non-English users. 
- Surface basic usage, feature list and HACS installation steps in German, Spanish, French, Polish and Portuguese.

### Description

- Add translated README files: `README.de.md`, `README.es.md`, `README.fr.md`, `README.pl.md`, and `README.pt.md`, each including an example image, feature list, and installation instructions. 
- Each localized README references the canonical English `README.md` for full configuration details and retains notes about `sun.sun` day/night switching and the `images` folder for house layouts.

### Testing

- No automated tests were added or executed for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad833d4ac832788fe709903eb3950)