### PR TITLE
Add GitHub Actions workflow to run hassfest

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,0 +1,17 @@
+name: Hassfest
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  hassfest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run hassfest
+        uses: home-assistant/actions/hassfest@master


### PR DESCRIPTION
### Motivation

- Add automated validation of Home Assistant integration metadata and configuration using `hassfest` on PRs and pushes to reduce merge-time errors.

### Description

- Add `.github/workflows/hassfest.yml` which triggers on `pull_request` and `push` to `main` and runs `home-assistant/actions/hassfest@master`.

### Testing

- No automated tests were executed for this PR; the new workflow will run `hassfest` on subsequent pushes and PRs to `main`, with results reported by GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae892a8a48327b60f7c08a00a5b5d)