### PR TITLE
Skip hassfest job for repositories without integrations

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   hassfest:
+    if: ${{ hashFiles('custom_components/**') != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Motivation
- Prevent the `hassfest` GitHub Actions job from failing with `Error: No integrations found!` in repositories that provide frontend assets but have no Home Assistant integrations by only running it when integration files exist under `custom_components/**`.

### Description
- Added a job-level condition `if: ${{ hashFiles('custom_components/**') != '' }}` to `.github/workflows/hassfest.yml` so the `hassfest` job is skipped when there are no files in `custom_components/**`.

### Testing
- No automated tests were run for this workflow-only guard; the change was verified via `git diff` and committed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faed5c71c0832787d35c0d7416da00)