### PR TITLE
Add configurable auto W/kW power formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ day_image: /local/solar/haus_tag.png
 units:
   power: W
   battery: "%"
+power_display_mode: auto_kw
+power_decimals: 1
 ```
 
 ## Card options
@@ -94,6 +96,8 @@ units:
 - `entities.wallbox_power` (entity id)
 - `units.power` (string, default: `W`)
 - `units.battery` (string, default: `%`)
+- `power_display_mode` (string, default: `raw`; options: `raw`, `auto_kw`)
+- `power_decimals` (number, default: `0`; used in `auto_kw` mode for both W and kW values, range: `0`-`3`)
 
 ## Validation
 

--- a/dist/ha-solar-dashboard.js
+++ b/dist/ha-solar-dashboard.js
@@ -132,6 +132,8 @@ class HaSolarDashboardCard extends HTMLElement {
       hud_box_opacity: 0.65,
       hud_box_scale: 1,
       daylight_entity: "sun.sun",
+      power_display_mode: "raw",
+      power_decimals: 0,
       units: { power: "W", battery: "%" },
       entities: {},
       positions: {},
@@ -156,6 +158,7 @@ class HaSolarDashboardCard extends HTMLElement {
 
     this.config.hud_box_opacity = this._clampNumber(this.config.hud_box_opacity, 0.65, 0, 1);
     this.config.hud_box_scale = this._clampNumber(this.config.hud_box_scale, 1, 0.6, 1.8);
+    this.config.power_decimals = this._clampNumber(this.config.power_decimals, 0, 0, 3);
 
     this._selectedHouse = house;
 
@@ -216,9 +219,29 @@ class HaSolarDashboardCard extends HTMLElement {
 
   _formatReading(metric) {
     const entityId = this.config.entities[metric.key];
-    const value = this._formatValue(this._getEntityValue(entityId, "0"));
+    const value = this._getEntityValue(entityId, "0");
+    if (metric.unit === "power") return this._formatPowerValue(value);
+    return this._formatWithUnit(value, this.config.units[metric.unit]);
+  }
+
+  _formatWithUnit(rawValue, unit) {
+    const value = this._formatValue(rawValue);
     if (value === "—") return value;
-    return `${value} ${this.config.units[metric.unit]}`;
+    return `${value} ${unit}`;
+  }
+
+  _formatPowerValue(rawValue) {
+    const numericValue = Number(rawValue);
+    if (!Number.isFinite(numericValue)) return this._formatWithUnit(rawValue, this.config.units.power);
+
+    const mode = this.config.power_display_mode || "raw";
+    if (mode === "auto_kw" && Math.abs(numericValue) >= 1000) {
+      const kwValue = numericValue / 1000;
+      return `${kwValue.toFixed(this.config.power_decimals)} kW`;
+    }
+
+    if (mode === "auto_kw") return `${numericValue.toFixed(this.config.power_decimals)} W`;
+    return `${numericValue} ${this.config.units.power}`;
   }
 
   _visibleMetrics() {
@@ -569,6 +592,15 @@ class HaSolarDashboardCardEditor extends HTMLElement {
         </label>
         <label>HUD box scale (${this._escape((Number(this._config.hud_box_scale ?? 1)).toFixed(2))})
           <input type="range" min="0.6" max="1.8" step="0.05" data-path="hud_box_scale" value="${this._escape(this._config.hud_box_scale ?? 1)}" />
+        </label>
+        <label>Power display mode
+          <select data-path="power_display_mode">
+            <option value="raw"${(this._config.power_display_mode || "raw") === "raw" ? " selected" : ""}>Raw value + configured unit</option>
+            <option value="auto_kw"${this._config.power_display_mode === "auto_kw" ? " selected" : ""}>Auto W/kW</option>
+          </select>
+        </label>
+        <label>Power decimals (${this._escape(Number(this._config.power_decimals ?? 0).toFixed(0))})
+          <input type="range" min="0" max="3" step="1" data-path="power_decimals" value="${this._escape(this._config.power_decimals ?? 0)}" />
         </label>
         <div class="section-title">Boxen anzeigen und positionieren</div>
         <div class="grid">${METRICS.map((metric) => this._renderBoxField(metric)).join("")}</div>

--- a/ha-solar-dashboard.js
+++ b/ha-solar-dashboard.js
@@ -132,6 +132,8 @@ class HaSolarDashboardCard extends HTMLElement {
       hud_box_opacity: 0.65,
       hud_box_scale: 1,
       daylight_entity: "sun.sun",
+      power_display_mode: "raw",
+      power_decimals: 0,
       units: { power: "W", battery: "%" },
       entities: {},
       positions: {},
@@ -156,6 +158,7 @@ class HaSolarDashboardCard extends HTMLElement {
 
     this.config.hud_box_opacity = this._clampNumber(this.config.hud_box_opacity, 0.65, 0, 1);
     this.config.hud_box_scale = this._clampNumber(this.config.hud_box_scale, 1, 0.6, 1.8);
+    this.config.power_decimals = this._clampNumber(this.config.power_decimals, 0, 0, 3);
 
     this._selectedHouse = house;
 
@@ -216,9 +219,29 @@ class HaSolarDashboardCard extends HTMLElement {
 
   _formatReading(metric) {
     const entityId = this.config.entities[metric.key];
-    const value = this._formatValue(this._getEntityValue(entityId, "0"));
+    const value = this._getEntityValue(entityId, "0");
+    if (metric.unit === "power") return this._formatPowerValue(value);
+    return this._formatWithUnit(value, this.config.units[metric.unit]);
+  }
+
+  _formatWithUnit(rawValue, unit) {
+    const value = this._formatValue(rawValue);
     if (value === "—") return value;
-    return `${value} ${this.config.units[metric.unit]}`;
+    return `${value} ${unit}`;
+  }
+
+  _formatPowerValue(rawValue) {
+    const numericValue = Number(rawValue);
+    if (!Number.isFinite(numericValue)) return this._formatWithUnit(rawValue, this.config.units.power);
+
+    const mode = this.config.power_display_mode || "raw";
+    if (mode === "auto_kw" && Math.abs(numericValue) >= 1000) {
+      const kwValue = numericValue / 1000;
+      return `${kwValue.toFixed(this.config.power_decimals)} kW`;
+    }
+
+    if (mode === "auto_kw") return `${numericValue.toFixed(this.config.power_decimals)} W`;
+    return `${numericValue} ${this.config.units.power}`;
   }
 
   _visibleMetrics() {
@@ -569,6 +592,15 @@ class HaSolarDashboardCardEditor extends HTMLElement {
         </label>
         <label>HUD box scale (${this._escape((Number(this._config.hud_box_scale ?? 1)).toFixed(2))})
           <input type="range" min="0.6" max="1.8" step="0.05" data-path="hud_box_scale" value="${this._escape(this._config.hud_box_scale ?? 1)}" />
+        </label>
+        <label>Power display mode
+          <select data-path="power_display_mode">
+            <option value="raw"${(this._config.power_display_mode || "raw") === "raw" ? " selected" : ""}>Raw value + configured unit</option>
+            <option value="auto_kw"${this._config.power_display_mode === "auto_kw" ? " selected" : ""}>Auto W/kW</option>
+          </select>
+        </label>
+        <label>Power decimals (${this._escape(Number(this._config.power_decimals ?? 0).toFixed(0))})
+          <input type="range" min="0" max="3" step="1" data-path="power_decimals" value="${this._escape(this._config.power_decimals ?? 0)}" />
         </label>
         <div class="section-title">Boxen anzeigen und positionieren</div>
         <div class="grid">${METRICS.map((metric) => this._renderBoxField(metric)).join("")}</div>


### PR DESCRIPTION
### Motivation
- Improve readability of large power readings by auto-switching between W and kW when appropriate. 
- Give users control over formatting precision for power values with a safe clamped `power_decimals` option. 
- Expose the new behavior in the card editor and documentation so the feature is discoverable and configurable.

### Description
- Add `power_display_mode` (`raw` | `auto_kw`) and `power_decimals` (0–3) to runtime config with defaults and clamping via `this.config.power_decimals = this._clampNumber(...)` and `power_display_mode: "raw"` in `setConfig`.
- Implement `_formatPowerValue` and `_formatWithUnit` to optionally convert values >= 1000 W to kW using the configured `power_decimals`, and route power metrics through this formatter in `_formatReading`.
- Add editor UI controls for `Power display mode` and `Power decimals` so the options can be changed from the visual card editor, and update the example YAML and options list in `README.md`.
- Sync `dist/ha-solar-dashboard.js` with the updated source so the distributable matches the source bundle shipped in the repository.

### Testing
- Ran the project validation with `npm test` which runs `node tests/validate-hacs-package.mjs`, and it initially failed because `dist/ha-solar-dashboard.js` did not match the source file. (failed)
- After syncing the distributable (`dist/ha-solar-dashboard.js`) with the updated source, re-running `npm test` passed and HACS package validation succeeded. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4c35feb88327825716cf4fdc58d7)