### PR TITLE
Use GitHub CLI to upload release assets and ensure release exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,17 @@ jobs:
           cp dist/ha-solar-dashboard.js release-assets/ha-solar-dashboard.js
           find dist/images -type f -name "*.png" -exec cp {} release-assets/ \;
 
+      - name: Ensure release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "${{ steps.release.outputs.tag }}" >/dev/null 2>&1 || \
+            gh release create "${{ steps.release.outputs.tag }}" \
+              --title "${{ steps.release.outputs.tag }}" \
+              --notes "Automated release for ${{ steps.release.outputs.tag }}"
+
       - name: Publish release assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.release.outputs.tag }}
-          files: release-assets/*
-          overwrite_files: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.release.outputs.tag }}" release-assets/* --clobber


### PR DESCRIPTION
### Motivation
- The release workflow was failing with a 404 when publishing assets via `softprops/action-gh-release`, so switching to the GitHub CLI avoids that REST endpoint path and ensures uploads succeed even if the release object is missing.

### Description
- Updated `.github/workflows/release.yml` to add an `Ensure release exists` step that runs `gh release view ... || gh release create ...` with `GH_TOKEN` to create the release object when needed.
- Replaced the `softprops/action-gh-release` step with a `gh release upload "${{ steps.release.outputs.tag }}" release-assets/* --clobber` run step that uploads and reliably overwrites assets using `GH_TOKEN`.
- Preserved the existing `Prepare release assets` step that copies `dist/ha-solar-dashboard.js` and PNG assets into `release-assets` prior to upload.

### Testing
- Ran `npm test` (HACS package validation) and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04889295e88327bb543d0f7a40acc0)